### PR TITLE
FIX: Adds missing Link from Gatsby on 404 page

### DIFF
--- a/smooth-doc/pages/404.mdx
+++ b/smooth-doc/pages/404.mdx
@@ -4,6 +4,7 @@ title: Page not found
 
 import { Box } from '@xstyled/styled-components'
 import { Article, ScreenContainer, Button } from '../components'
+import { Link } from "gatsby"
 import notFoundImageURL from '../images/404.png'
 
 <Article style={{ textAlign: 'center', overflow: 'hidden' }}>


### PR DESCRIPTION
Build fails without this

```
Building static HTML failed for path "/404/"
...
WebpackError: ReferenceError: Link is not defined
```
fixes #15

## Summary

Fixes #15 which prevents any smooth-doc project from building.

## Test plan

On a blank smooth-doc repo: 

```
yarn build
```

It should build.
