### PR TITLE
Transforms internal links in Link components

### DIFF
--- a/smooth-doc/src/components/MDX.js
+++ b/smooth-doc/src/components/MDX.js
@@ -26,11 +26,19 @@ export const mdxComponents = {
     const codeChild = getCodeChild(children)
     return <pre>{codeChild ? transformCode(codeChild.props) : children}</pre>
   },
-  // transforms internal links in MDX into GatsbyLink components
-  a: ({ href, ...p }) => {
-    // Link don't support external links or anchors 
+// transforms internal links in MDX into GatsbyLink components
+  a: ({ href, children, ...p }) => {
+    // Link don't support external links or anchors
     const isLink = href.indexOf('http') === -1 && href.indexOf('#') !== 0
-    return isLink ? <Link to={href} {...p} /> : <a href={href} {...p} />
+    return isLink ? (
+      <Link to={href} {...p}>
+        {children}
+      </Link>
+    ) : (
+      <a href={href} {...p}>
+        {children}
+      </a>
+    )
   },
 }
 

--- a/smooth-doc/src/components/MDX.js
+++ b/smooth-doc/src/components/MDX.js
@@ -26,6 +26,12 @@ export const mdxComponents = {
     const codeChild = getCodeChild(children)
     return <pre>{codeChild ? transformCode(codeChild.props) : children}</pre>
   },
+  // transforms internal links in MDX into GatsbyLink components
+  a: ({ href, ...p }) => {
+    // Link don't support external links or anchors 
+    const isLink = href.indexOf('http') === -1 && href.indexOf('#') !== 0
+    return isLink ? <Link to={href} {...p} /> : <a href={href} {...p} />
+  },
 }
 
 export function MDXProvider({ children, components }) {

--- a/smooth-doc/src/components/MDX.js
+++ b/smooth-doc/src/components/MDX.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Link } from 'gatsby'
 import { MDXProvider as BaseMDXProvider } from '@mdx-js/react'
 import { Code } from './Code'
 import { CarbonAd } from './CarbonAd'


### PR DESCRIPTION
## Summary

`gatsby-plugin-mdx` doesn't seem to transform internal markdown links into Gatsby `<Link />` components resulting in page being refreshed. 

Consider the code below:

```mdx
Go to [docs](/docs/)

Go to [Github](https://github.com)

Go to [AnchorLink](#Title)

### Title
```

### Before

All links are rendered with `<a />`. The first link, while internal, doesn't use Gatsby `<Link />`.

![image](https://user-images.githubusercontent.com/5003380/97809172-aaf20c00-1c6b-11eb-9a09-cba788ee908d.png)

### After

The first link is internal and is rightfully rendered using Gatsby `<Link />`. Clicking on the link doesn't trigger a page reload.

![image](https://user-images.githubusercontent.com/5003380/97809206-e2f94f00-1c6b-11eb-9706-4827f8e14833.png)

