### PR TITLE
Fix gatsby-plugin-mdx warning in console

### DIFF
--- a/smooth-doc/gatsby-node.js
+++ b/smooth-doc/gatsby-node.js
@@ -28,14 +28,6 @@ function createSchemaCustomization({ actions }) {
       carbonAdsURL: String
       docSearch: AlgoliaDocSearchMetadata
     }
-
-    type MdxFrontmatter {
-      title: String!
-      slug: String
-      section: String
-      order: Int
-      redirect: String
-    }
   `
   createTypes(typeDefs)
 }


### PR DESCRIPTION
## Summary

Currently, the terminal shows this warning:

```bash
warning Plugin `gatsby-plugin-mdx` has customized the GraphQL type `MdxFrontmatter`, which has already been defined by the plugin `smooth-doc`. This could potentially cause conflicts.
```

This PR removes the warning.

Disclaimer: I'm not sure why this was pushed in the first place, maybe there is a good reason for this!