### PR TITLE
Add instructions to add code highlighting for an unsupported language

### DIFF
--- a/website/pages/docs/mdx.mdx
+++ b/website/pages/docs/mdx.mdx
@@ -42,7 +42,7 @@ Your page content...
 
 ## Code
 
-To include a highlighted code snippet, use markdown code block syntax followed by language. Syntax highlighting is built-in thanks to [Prism](https://prismjs.com/). Almost all languages are supported.
+To include a highlighted code snippet, use markdown code block syntax followed by language. Syntax highlighting is built-in thanks to [Prism](https://prismjs.com/).
 
 ````md
 An example of code block:
@@ -53,6 +53,20 @@ const foo = 'bar'
 ````
 
 Read [React Live Editor Guide](/docs/react-live-editor/) to learn how to create interactive examples.
+
+### Supported languages
+
+By default, all languages included in [prism-react-renderer](https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/vendor/prism/includeLangs.js) are supported.
+
+If you want to highlight code in another language such as Rust, you can enable it by adding the following in `gatsby-browser.js` ([see GitHub issue](https://github.com/FormidableLabs/prism-react-renderer/issues/53#issuecomment-546653848)):
+
+```js
+import Prism from 'prism-react-renderer/prism'
+
+(typeof global !== 'undefined' ? global : window).Prism = Prism
+
+require('prismjs/components/prism-rust')
+```
 
 ## Custom components
 

--- a/website/pages/docs/mdx.mdx
+++ b/website/pages/docs/mdx.mdx
@@ -58,13 +58,14 @@ Read [React Live Editor Guide](/docs/react-live-editor/) to learn how to create 
 
 By default, all languages included in [prism-react-renderer](https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/vendor/prism/includeLangs.js) are supported.
 
-If you want to highlight code in another language such as Rust, you can enable it by adding the following in `gatsby-browser.js` ([see GitHub issue](https://github.com/FormidableLabs/prism-react-renderer/issues/53#issuecomment-546653848)):
+If you want to highlight code in another language such as Ruby or Rust, you can enable it by adding the following in `gatsby-browser.js` ([see GitHub issue](https://github.com/FormidableLabs/prism-react-renderer/issues/53#issuecomment-546653848)):
 
 ```js
 import Prism from 'prism-react-renderer/prism'
 
 (typeof global !== 'undefined' ? global : window).Prism = Prism
 
+require('prismjs/components/prism-ruby')
 require('prismjs/components/prism-rust')
 ```
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

The documentation currently states "Almost all languages are supported". While that is true, there are a few notable exceptions including Ruby and Rust. It may be helpful to know exactly how to add support for it :)

## Test plan

This is documentation only. It could be tested by adding a code sample in Rust, perhaps?