### PR TITLE
Fix previous/back navigation with --prefix-paths

### DIFF
--- a/smooth-doc/src/components/SideNav.js
+++ b/smooth-doc/src/components/SideNav.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useStaticQuery, graphql, Link } from 'gatsby'
+import { useStaticQuery, graphql, Link, withPrefix } from 'gatsby'
 import styled from '@xstyled/styled-components'
 // eslint-disable-next-line import/no-unresolved
 import { useLocation } from '@reach/router'
@@ -135,7 +135,9 @@ export function useSideNavState() {
 export function useSideNavPrevNext({ navGroups }) {
   const { pathname } = useLocation()
   const nodes = navGroups.flatMap((group) => group.nodes)
-  const nodeIndex = nodes.findIndex((node) => node.fields.slug === pathname)
+  const nodeIndex = nodes.findIndex(
+    (node) => withPrefix(node.fields.slug) === pathname,
+  )
   return {
     prev: nodeIndex > -1 ? nodes[nodeIndex - 1] : null,
     next: nodeIndex > -1 ? nodes[nodeIndex + 1] : null,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

This fixes #41, ensuring the previous/back navigation appears even when the website is served in a nested path with `gatsby build --prefix-paths`.

See https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-link/#add-the-path-prefix-to-paths-using-withprefix for the relevant documentation.

## Test plan

See reproduction notes in https://github.com/gregberge/smooth-doc/issues/41.

Sorry this comes three months later... Better late than never :)
