### PR TITLE
add appId configuration parameter

### DIFF
--- a/smooth-doc/gatsby-config.js
+++ b/smooth-doc/gatsby-config.js
@@ -23,7 +23,7 @@ function getLogoPath() {
  * @param {string} [options.githubDefaultBranch]
  * @param {string} [options.author]
  * @param {string} [options.carbonAdsURL]
- * @param {{ apiKey: string, indexName: string }} [options.docSearch]
+ * @param {{ apiKey: string, indexName: string, appId: string }} [options.docSearch]
  * @param {object} [options.sitemap]
  */
 module.exports = (options) => {

--- a/smooth-doc/gatsby-node.js
+++ b/smooth-doc/gatsby-node.js
@@ -14,6 +14,7 @@ function createSchemaCustomization({ actions }) {
     type AlgoliaDocSearchMetadata {
       apiKey: String!
       indexName: String!
+      appId: String
     }
 
     type SiteSiteMetadata {
@@ -239,6 +240,7 @@ const pluginOptionsSchema = (/** @type {{ Joi: import('joi') }} */ { Joi }) => {
     docSearch: Joi.object({
       apiKey: Joi.string().required(),
       indexName: Joi.string().required(),
+      appId: Joi.string(),
     }),
     sitemap: Joi.object(),
   })

--- a/smooth-doc/src/components/AppHeader.js
+++ b/smooth-doc/src/components/AppHeader.js
@@ -27,6 +27,7 @@ const AppHeaderQuery = graphql`
         docSearch {
           apiKey
           indexName
+          appId
         }
         navItems {
           title

--- a/smooth-doc/src/components/DocSearch.js
+++ b/smooth-doc/src/components/DocSearch.js
@@ -58,7 +58,7 @@ const Kbd = styled.kbd`
 
 let DocSearchModal = null
 
-export const DocSearch = ({ apiKey, indexName }) => {
+export const DocSearch = ({ apiKey, indexName, appId }) => {
   const searchButtonRef = React.useRef(null)
   const [isShowing, setIsShowing] = React.useState(false)
   const [initialQuery, setInitialQuery] = React.useState(null)
@@ -143,6 +143,7 @@ export const DocSearch = ({ apiKey, indexName }) => {
           <DocSearchModal
             apiKey={apiKey}
             indexName={indexName}
+            appId={appId}
             initialQuery={initialQuery}
             onClose={onClose}
             navigator={{

--- a/smooth-doc/src/components/DocSearch.js
+++ b/smooth-doc/src/components/DocSearch.js
@@ -143,7 +143,7 @@ export const DocSearch = ({ apiKey, indexName, appId }) => {
           <DocSearchModal
             apiKey={apiKey}
             indexName={indexName}
-            appId={appId}
+            appId={appId  ?? 'BH4D9OD16A'}
             initialQuery={initialQuery}
             onClose={onClose}
             navigator={{

--- a/website/pages/docs/docsearch.mdx
+++ b/website/pages/docs/docsearch.mdx
@@ -32,6 +32,7 @@ module.exports = {
         docSearch: {
           apiKey: '...',
           indexName: '...',
+          appId: '...', // optional
         },
       },
     },

--- a/website/pages/docs/options.mdx
+++ b/website/pages/docs/options.mdx
@@ -102,6 +102,6 @@ Your Carbon Ads URL. Read [Display Ads guide](/docs/ads/) to learn how to displa
 
 ### docSearch
 
-`{ apiKey: string, indexName: string }`
+`{ apiKey: string, indexName: string, appId: string }`
 
 Configuration of your [Algolia DocSearch](https://docsearch.algolia.com/) account. Read [DocSearch guide](/docs/docsearch/) for more information.


### PR DESCRIPTION
## Summary

add `appId` parameter to make this option configurable as well. See #51 

## Test plan

Unfortunately I was unable to test the changes locally with my fork, maybe you can take a look
