### PR TITLE
Fix for broken URLs on the `Edit this page on GitHub` links

### DIFF
--- a/smooth-doc/gatsby-node.js
+++ b/smooth-doc/gatsby-node.js
@@ -131,7 +131,7 @@ function onCreateMdxNode({ node, getNode, actions }, options) {
       baseDirectory,
       githubDocRepositoryURL,
       githubRepositoryURL,
-      githubDefaultBranch = 'master',
+      githubDefaultBranch = 'main',
     } = options
     const repositoryURL = githubDocRepositoryURL || githubRepositoryURL
     if (!baseDirectory || !repositoryURL) return ''

--- a/smooth-doc/gatsby-node.js
+++ b/smooth-doc/gatsby-node.js
@@ -136,7 +136,7 @@ function onCreateMdxNode({ node, getNode, actions }, options) {
     const repositoryURL = githubDocRepositoryURL || githubRepositoryURL
     if (!baseDirectory || !repositoryURL) return ''
     const relativePath = node.fileAbsolutePath.replace(baseDirectory, '')
-    return `${repositoryURL}/edit/${githubDefaultBranch}${relativePath}`
+    return `${repositoryURL}edit/${githubDefaultBranch}${relativePath}`
   }
 
   createNodeField({


### PR DESCRIPTION
At the moment the `Edit this page on GitHub` URLs look like this: https://github.com/gregberge/smooth-doc//edit/master/website/pages/docs/theme.mdx
Note the double slash before `edit`.

This PR removes the extra slash.