### PR TITLE
Add Aria Labels

### DIFF
--- a/smooth-doc/src/components/AppNav.js
+++ b/smooth-doc/src/components/AppNav.js
@@ -39,6 +39,7 @@ export function AppNav() {
               href={data.site.siteMetadata.githubRepositoryURL}
               target="_blank"
               rel="noopener noreferrer"
+              aria-label="Github"
             >
               <RiGithubFill style={{ width: 24, height: 24 }} />
             </NavLink>
@@ -49,6 +50,7 @@ export function AppNav() {
             <NavLink
               as="a"
               href={`https://twitter.com/${data.site.siteMetadata.twitterAccount}`}
+              aria-label="Twitter"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -57,7 +59,7 @@ export function AppNav() {
           </NavListItem>
         ) : null}
         <NavListItem>
-          <NavLink as={ColorModeSwitcher} />
+          <NavLink aria-label="Switch Theme" as={ColorModeSwitcher} />
         </NavListItem>
       </NavList>
     </Nav>


### PR DESCRIPTION
## Summary

I added Aria labels for links and buttons on top header, for better **accessibility** 

https://dequeuniversity.com/rules/axe/4.4/button-name?utm_source=lighthouse&utm_medium=lr

It is nice to have.

## Test plan

It simply adds aria-label attributes for Github, Twitter and Colour Switcher buttons. 

It also helps in better SEO and better pagespeed insight score

Thank You